### PR TITLE
Use .dotenv to load environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /node_modules/
 /.idea/
 /.fleet/
+
 .envrc
+.env

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Linting checks for common bugs.
 
 ### Run the script
 
-You will have to set all relevant environment variables for this to work. Consider using [direnv](https://direnv.net) and an .envrc file. Be careful to never share this file!
+You will have to set all relevant environment variables in `.env` for this to work. Be careful to never share this file!
 
 Then, choose the services you want to scrape. Run `npm start -- --help` to see the choices.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@influxdata/influxdb-client": "^1.33.2",
         "axios": "^1.4.0",
+        "dotenv": "^16.3.1",
         "papaparse": "^5.4.1",
         "yargs": "^17.7.2"
       },
@@ -496,6 +497,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@influxdata/influxdb-client": "^1.33.2",
     "axios": "^1.4.0",
+    "dotenv": "^16.3.1",
     "papaparse": "^5.4.1",
     "yargs": "^17.7.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { InfluxDB } from "@influxdata/influxdb-client";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";


### PR DESCRIPTION
I couldn't get Direnv to work on Windows, which led me to finding this tool. This is a much simpler setup anyways than Direnv.

You don't have to set up a `.env` file (e.g. CI), you only can if you prefer.