### PR TITLE
Add `runProcess` util

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
 
+import { exec, ExecOptions } from "child_process";
+
 import { Point } from "@influxdata/influxdb-client";
 
 const NOW_S = Math.floor(Date.now() / 1000);
@@ -18,4 +20,22 @@ const createCountPoint = (
     .intField("count", count)
     .timestamp(timestampInSeconds);
 
-export { createCountPoint, log, NOW_S };
+const runProcess = (
+  cmd: string,
+  options?: ExecOptions
+): Promise<[string, string]> =>
+  new Promise((resolve, reject) => {
+    exec(cmd, options, (error, stdout, stderr) => {
+      if (error) {
+        return reject(error);
+      }
+      if (stdout instanceof Buffer || stderr instanceof Buffer) {
+        return reject(
+          new Error("stdout or stderr is Buffer, which is not supported")
+        );
+      }
+      return resolve([stdout, stderr]);
+    });
+  });
+
+export { createCountPoint, log, runProcess, NOW_S };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+import { runProcess } from "../src/utils";
+
+test.describe("runProcess", () => {
+  test("captures stdout", async () => {
+    const [stdout, stderr] = await runProcess("echo 'hello world'");
+    expect(stdout).toEqual("hello world\n");
+    expect(stderr).toEqual("");
+  });
+
+  test("captures stderr", async () => {
+    const [stdout, stderr] = await runProcess("echo 'hello world' 1>&2");
+    expect(stdout).toEqual("");
+    expect(stderr).toEqual("hello world\n");
+  });
+
+  test("errors on failures", async () => {
+    try {
+      await runProcess("fake-process");
+    } catch (error) {
+      expect(error).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
Node.js's interface for running subprocesses is not very ergonomic. This wraps it in a helper function that allows us to use async/await, which is much more natural.

It intentionally errors on failures to keep things simple. We don't need to handle failed subprocesses in this repository.

It returns `[stdout, stderr]` so that we can e.g. parse the result of `git log`.