### PR TITLE
Split up map projects parsing functions

### DIFF
--- a/src/mapProjects.ts
+++ b/src/mapProjects.ts
@@ -9,26 +9,23 @@ const MANDATES_CSV =
 const CITIES_JSON =
   "https://raw.githubusercontent.com/ParkingReformNetwork/parking-lot-map/main/data/score-cards.json";
 
-const parsePoints = (
-  mandatesCsvData: string,
-  citiesJsonData: Record<string, unknown>
-): Point[] => {
-  const mandatesParsedData = Papa.parse(mandatesCsvData, { header: true });
-  const mandateCount = mandatesParsedData.data.length;
-
-  const cityCount = Object.keys(citiesJsonData).length;
-  return [
-    createCountPoint("mandates-map-entries", mandateCount),
-    createCountPoint("parking-lot-map-entries", cityCount),
-  ];
+const parseMandatesCsv = (csv: string): Point => {
+  const parsed = Papa.parse(csv, { header: true });
+  return createCountPoint("mandates-map-entries", parsed.data.length);
 };
+
+const parseCitiesJson = (jsonData: Record<string, unknown>): Point =>
+  createCountPoint("parking-lot-map-entries", Object.keys(jsonData).length);
 
 const getCurrentPoints = async (): Promise<Point[]> => {
   const [mandatesResponse, cities] = await Promise.all([
     axios.get(MANDATES_CSV, { responseType: "text" }),
     axios.get(CITIES_JSON, { responseType: "json" }),
   ]);
-  return parsePoints(mandatesResponse.data, cities.data);
+  return [
+    parseMandatesCsv(mandatesResponse.data),
+    parseCitiesJson(cities.data),
+  ];
 };
 
 const getHistoricalPoints = async (): Promise<Point[]> => [];
@@ -36,5 +33,6 @@ const getHistoricalPoints = async (): Promise<Point[]> => [];
 export default {
   getCurrentPoints,
   getHistoricalPoints,
-  parsePoints,
+  parseCitiesJson,
+  parseMandatesCsv,
 };

--- a/tests/mapProjects.test.ts
+++ b/tests/mapProjects.test.ts
@@ -5,17 +5,15 @@ import { expect, test } from "@playwright/test";
 import mapProjects from "../src/mapProjects";
 import { createCountPoint } from "../src/utils";
 
-test("parsing maps", async () => {
-  const mandates = await fs.readFile("tests/mocks/mandates-map.csv", "utf8");
-  const parkingRaw = await fs.readFile(
-    "tests/mocks/parking-lot-map.json",
-    "utf8"
-  );
-  const parking = JSON.parse(parkingRaw);
+test("parseCitiesJson", async () => {
+  const raw = await fs.readFile("tests/mocks/parking-lot-map.json", "utf8");
+  const parsed = JSON.parse(raw);
+  const result = mapProjects.parseCitiesJson(parsed);
+  expect(result).toEqual(createCountPoint("parking-lot-map-entries", 52));
+});
 
-  const result = mapProjects.parsePoints(mandates, parking);
-  expect(result).toEqual([
-    createCountPoint("mandates-map-entries", 1552),
-    createCountPoint("parking-lot-map-entries", 52),
-  ]);
+test("parseMandatesCsv", async () => {
+  const csv = await fs.readFile("tests/mocks/mandates-map.csv", "utf8");
+  const result = mapProjects.parseMandatesCsv(csv);
+  expect(result).toEqual(createCountPoint("mandates-map-entries", 1552));
 });


### PR DESCRIPTION
For historical data (https://github.com/ParkingReformNetwork/organization-dashboard/issues/36), I realized that the timestamps will be different between the two map projects. We need to be able to create a Point for only one map without worrying about the other.