### PR TITLE
Fix runProcess to fully finish the process

### DIFF
--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -4,20 +4,23 @@ import { runProcess } from "../src/utils";
 
 test.describe("runProcess", () => {
   test("captures stdout", async () => {
-    const [stdout, stderr] = await runProcess("echo 'hello world'");
+    const [stdout, stderr] = await runProcess("echo", ["hello world"]);
     expect(stdout).toEqual("hello world\n");
     expect(stderr).toEqual("");
   });
 
   test("captures stderr", async () => {
-    const [stdout, stderr] = await runProcess("echo 'hello world' 1>&2");
+    const [stdout, stderr] = await runProcess("node", [
+      "-e",
+      "console.error('hello world')",
+    ]);
     expect(stdout).toEqual("");
     expect(stderr).toEqual("hello world\n");
   });
 
   test("errors on failures", async () => {
     try {
-      await runProcess("fake-process");
+      await runProcess("fake-process", []);
     } catch (error) {
       expect(error).toBeTruthy();
     }


### PR DESCRIPTION
`exec` did not wait for the `git` process to finish, which caused issues when using `git checkout` >1 time in a row. We should have been using the `spawn` API instead.